### PR TITLE
Add Document type plus GraphQL fields

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,3 +1,5 @@
 alias Schole.Repo
+alias Schole.Documents
+alias Schole.Documents.Document
 alias Schole.Projects
 alias Schole.Projects.Project

--- a/lib/schole/documents.ex
+++ b/lib/schole/documents.ex
@@ -1,0 +1,18 @@
+defmodule Schole.Documents do
+  alias Schole.Repo
+  alias Schole.Documents.Document
+
+  def all() do
+    Repo.all(Document)
+  end
+
+  def find(args) do
+    Repo.get_by(Document, args)
+  end
+
+  def create(attrs \\ %{}) do
+    %Document{}
+    |> Document.create_changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/schole/documents.ex
+++ b/lib/schole/documents.ex
@@ -1,4 +1,6 @@
 defmodule Schole.Documents do
+  import Ecto.Query
+
   alias Schole.Repo
   alias Schole.Documents.Document
 
@@ -7,7 +9,11 @@ defmodule Schole.Documents do
   end
 
   def find(args) do
-    Repo.get_by(Document, args)
+    q =  Enum.reduce(args, Document, fn {key, val}, queryable ->
+      where(queryable, ^dynamic([m], field(m, ^key) == ^val))
+    end)
+
+    Repo.all(q)
   end
 
   def create(attrs \\ %{}) do

--- a/lib/schole/documents/document.ex
+++ b/lib/schole/documents/document.ex
@@ -1,0 +1,23 @@
+defmodule Schole.Documents.Document do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Schole.Documents.Document
+
+  @required ~w(title content)
+  @optional ~w(description metadata tags)
+
+  schema "documents" do
+    field :title, :string, null: false
+    field :description, :string
+    field :content, :string, null: false
+    field :metadata, :map
+    field :tags, {:array, :string}, default: []
+  end
+
+  def create_changeset(%Document{} = document, attrs \\ %{}) do
+    document
+    |> cast(attrs, @required ++ @optional)
+    |> validate_required(@required)
+  end
+end

--- a/lib/schole/documents/document.ex
+++ b/lib/schole/documents/document.ex
@@ -4,14 +4,14 @@ defmodule Schole.Documents.Document do
 
   alias Schole.Documents.Document
 
-  @required ~w(title content)
-  @optional ~w(description metadata tags)
+  @required ~w(title content)a
+  @optional ~w(description metadata tags)a
 
   schema "documents" do
     field :title, :string, null: false
     field :description, :string
     field :content, :string, null: false
-    field :metadata, :map
+    field :metadata, :map, default: %{}
     field :tags, {:array, :string}, default: []
   end
 

--- a/lib/schole_web/resolvers/documents_resolver.ex
+++ b/lib/schole_web/resolvers/documents_resolver.ex
@@ -9,7 +9,9 @@ defmodule ScholeWeb.Resolvers.DocumentsResolver do
   end
 
   def find(_parent, args, _resolution) do
-    Helpers.wrapped_call(Documents.find(args), "No document with those attributes found")
+    documents = Documents.find(args)
+
+    {:ok, documents}
   end
 
   def create(_parent, args, _resolution) do

--- a/lib/schole_web/resolvers/documents_resolver.ex
+++ b/lib/schole_web/resolvers/documents_resolver.ex
@@ -1,0 +1,18 @@
+defmodule ScholeWeb.Resolvers.DocumentsResolver do
+  alias Schole.Documents
+  alias ScholeWeb.Resolvers.Helpers
+
+  def all(_parent, _args, _resolution) do
+    documents = Documents.all()
+
+    {:ok, documents}
+  end
+
+  def find(_parent, args, _resolution) do
+    Helpers.wrapped_call(Documents.find(args), "No document with those attributes found")
+  end
+
+  def create(_parent, args, _resolution) do
+    Helpers.wrapped_call(fn -> Documents.create(args) end)
+  end
+end

--- a/lib/schole_web/resolvers/projects_resolver.ex
+++ b/lib/schole_web/resolvers/projects_resolver.ex
@@ -1,6 +1,7 @@
 defmodule ScholeWeb.Resolvers.ProjectsResolver do
   alias Ecto.Changeset
   alias Schole.Projects
+  alias ScholeWeb.Resolvers.Helpers
 
   def all(_parent, _args, _resolution) do
     projects = Projects.all
@@ -16,27 +17,6 @@ defmodule ScholeWeb.Resolvers.ProjectsResolver do
   end
 
   def create(_parent, args, _resolution) do
-    wrapped_call(fn -> Projects.create(args) end)
-  end
-
-  defp format_errors(changeset) do
-    errors = Changeset.traverse_errors(changeset, fn {msg, opts} ->
-      Enum.reduce(opts, msg, fn {k, v}, formatted_msg ->
-        formatted_msg |> String.replace("%{#{k}}", to_string(v))
-      end)
-    end)
-
-    %{
-      message: "Validation errors occurred",
-      code: :schema_errors,
-      errors: errors
-    }
-  end
-
-  defp wrapped_call(fun) do
-    case fun.() do
-      {:ok, result} -> {:ok, result}
-      {:error, %Changeset{} = changeset} -> {:error, format_errors(changeset)}
-    end
+    Helpers.wrapped_call(fn -> Projects.create(args) end)
   end
 end

--- a/lib/schole_web/resolvers/projects_resolver.ex
+++ b/lib/schole_web/resolvers/projects_resolver.ex
@@ -1,15 +1,16 @@
 defmodule ScholeWeb.Resolvers.ProjectsResolver do
-  alias Ecto.Changeset
   alias Schole.Projects
   alias ScholeWeb.Resolvers.Helpers
 
   def all(_parent, _args, _resolution) do
-    projects = Projects.all
+    projects = Projects.all()
 
     {:ok, projects}
   end
 
   def find(_parent, args, _resolution) do
+    Helpers.wrapped_call(fn -> Projects.find(args) end, "No project with those attributes found")
+
     case Projects.find(args) do
       nil -> {:error, "No project with those attributes found"}
       project -> {:ok, project}

--- a/lib/schole_web/resolvers/resolver_helpers.ex
+++ b/lib/schole_web/resolvers/resolver_helpers.ex
@@ -21,4 +21,11 @@ defmodule ScholeWeb.Resolvers.Helpers do
       {:error, %Changeset{} = changeset} -> {:error, format_errors(changeset)}
     end
   end
+
+  def wrapped_call(fun, msg) do
+    case fun.() do
+      nil -> {:error, msg}
+      result -> {:ok, result}
+    end
+  end
 end

--- a/lib/schole_web/resolvers/resolver_helpers.ex
+++ b/lib/schole_web/resolvers/resolver_helpers.ex
@@ -1,0 +1,24 @@
+defmodule ScholeWeb.Resolvers.Helpers do
+  alias Ecto.Changeset
+
+  def format_errors(changeset) do
+    errors = Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {k, v}, formatted_msg ->
+        formatted_msg |> String.replace("%{#{k}}", to_string(v))
+      end)
+    end)
+
+    %{
+      message: "Validation errors occurred",
+      code: :schema_errors,
+      errors: errors
+    }
+  end
+
+  def wrapped_call(fun) do
+    case fun.() do
+      {:ok, result} -> {:ok, result}
+      {:error, %Changeset{} = changeset} -> {:error, format_errors(changeset)}
+    end
+  end
+end

--- a/lib/schole_web/schema.ex
+++ b/lib/schole_web/schema.ex
@@ -2,7 +2,7 @@ defmodule ScholeWeb.Schema do
   use Absinthe.Schema
   import_types ScholeWeb.Schema.ContentTypes
 
-  alias ScholeWeb.Resolvers.ProjectsResolver
+  alias ScholeWeb.Resolvers.{DocumentsResolver, ProjectsResolver}
 
   query do
     @desc "Get all projects"
@@ -18,6 +18,19 @@ defmodule ScholeWeb.Schema do
 
       resolve &ProjectsResolver.find/3
     end
+
+    @desc "Get all documents"
+    field :documents, list_of(:document) do
+      resolve &DocumentsResolver.all/3
+    end
+
+    @desc "Find a document by some combination of ID and title"
+    field :find_documents, list_of(:document) do
+      arg :id, :id
+      arg :title, :string
+
+      resolve &DocumentsResolver.find/3
+    end
   end
 
   mutation do
@@ -28,6 +41,17 @@ defmodule ScholeWeb.Schema do
       arg :metadata, :json
 
       resolve &ProjectsResolver.create/3
+    end
+
+    @desc "Create a new document"
+    field :create_document, :document do
+      arg :title, non_null(:string)
+      arg :content, non_null(:string)
+      arg :description, :string
+      arg :metadata, :json
+      arg :tags, list_of(:string)
+
+      resolve &DocumentsResolver.create/3
     end
   end
 end

--- a/lib/schole_web/schema/content_types.ex
+++ b/lib/schole_web/schema/content_types.ex
@@ -8,4 +8,13 @@ defmodule ScholeWeb.Schema.ContentTypes do
     field :title, :string
     field :metadata, :json
   end
+
+  object :document do
+    field :id, :id
+    field :title, :string
+    field :description, :string
+    field :content, :string
+    field :metadata, :json
+    field :tags, list_of(:string)
+  end
 end

--- a/priv/repo/migrations/20200412181809_create_documents.exs
+++ b/priv/repo/migrations/20200412181809_create_documents.exs
@@ -6,7 +6,7 @@ defmodule Schole.Repo.Migrations.CreateDocuments do
       add :title, :string, null: false
       add :description, :string
       add :content, :string, null: false
-      add :metadata, :map
+      add :metadata, :map, default: %{}
       add :tags, {:array, :string}, default: []
     end
   end

--- a/priv/repo/migrations/20200412181809_create_documents.exs
+++ b/priv/repo/migrations/20200412181809_create_documents.exs
@@ -1,0 +1,13 @@
+defmodule Schole.Repo.Migrations.CreateDocuments do
+  use Ecto.Migration
+
+  def change do
+    create table(:documents) do
+      add :title, :string, null: false
+      add :description, :string
+      add :content, :string, null: false
+      add :metadata, :map
+      add :tags, {:array, :string}, default: []
+    end
+  end
+end


### PR DESCRIPTION
Documents are the first non-project type added to the GraphQL schema. At the moment they're extremely simple types but will become more complex over time.