### PR TITLE
Add adapter pattern for search implementations

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -4,5 +4,6 @@ alias Schole.{Documents, Projects, ReleaseNotes, Repo}
 alias Schole.Documents.Document
 alias Schole.Projects.Project
 alias Schole.ReleaseNotes.ReleaseNote
+alias Schole.Search
 
 import Ecto.Query

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,17 +1,9 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-#
-# This configuration file is loaded before any dependency and
-# is restricted to this project.
-
-# General application configuration
 use Mix.Config
 
 config :schole,
   ecto_repos: [Schole.Repo],
   generators: [binary_id: true]
 
-# Configures the endpoint
 config :schole, ScholeWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "oiIrKlvDBpqc83q9U4kvuHtaQ43N5ojBU4XCLMGrAyR4N4jjOksodwxZUTt57Rv8",
@@ -19,14 +11,17 @@ config :schole, ScholeWeb.Endpoint,
   pubsub: [name: Schole.PubSub, adapter: Phoenix.PubSub.PG2],
   live_view: [signing_salt: "ZTGi9Ji5"]
 
-# Configures Elixir's Logger
+config :schole, :search,
+  driver: Schole.Search.Postgres
+
+#config :schole, :search, Schole.Search,
+# driver: Schole.Search.Algolia,
+# api_key: System.get_env("ALGOLIA_API_KEY")
+
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-# Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-# Import environment specific config. This must remain at the bottom
-# of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,7 @@ config :schole, ScholeWeb.Endpoint,
   live_view: [signing_salt: "ZTGi9Ji5"]
 
 config :schole, :search,
-  driver: Schole.Search.Postgres
+  driver: Schole.Search.Postgres.ILike
 
 #config :schole, :search, Schole.Search,
 # driver: Schole.Search.Algolia,

--- a/lib/schole/documents.ex
+++ b/lib/schole/documents.ex
@@ -21,7 +21,7 @@ defmodule Schole.Documents do
     Repo.get(Document, id)
   end
 
-  def create(%{document: document, project_id: project_id} = attrs) do
+  def create(%{document: document, project_id: project_id}) do
     case Projects.get(project_id) do
       nil ->
         {:error, "Project with ID #{project_id} not found"}
@@ -38,5 +38,18 @@ defmodule Schole.Documents do
       nil -> {:error, :not_found}
       document -> Repo.delete(document)
     end
+  end
+
+  def search(query) do
+    provider = Application.get_env(:schole, :search)
+
+    case Application.get_env(:schole, :search) do
+      Schole.Search.Postgres -> search(:postgres, query)
+      _ -> {:error, "search provider #{provider} not recognized"}
+    end
+  end
+
+  def search(:postgres, query) do
+    Schole.Search.Postgres.search(query)
   end
 end

--- a/lib/schole/documents.ex
+++ b/lib/schole/documents.ex
@@ -39,17 +39,4 @@ defmodule Schole.Documents do
       document -> Repo.delete(document)
     end
   end
-
-  def search(query) do
-    provider = Application.get_env(:schole, :search)
-
-    case Application.get_env(:schole, :search) do
-      Schole.Search.Postgres -> search(:postgres, query)
-      _ -> {:error, "search provider #{provider} not recognized"}
-    end
-  end
-
-  def search(:postgres, query) do
-    Schole.Search.Postgres.search(query)
-  end
 end

--- a/lib/schole/search/postgres.ex
+++ b/lib/schole/search/postgres.ex
@@ -1,0 +1,17 @@
+defmodule Schole.Search.Postgres do
+  @moduledoc false
+
+  @behaviour Schole.Search
+
+  import Ecto.Query
+
+  alias Schole.Documents.Document
+  alias Schole.Repo
+
+  def search(query) do
+    q = from d in Document,
+      where: ilike(d.content, ^"%#{query}%")
+
+    Repo.all(q)
+  end
+end

--- a/lib/schole/search/postgres.ex
+++ b/lib/schole/search/postgres.ex
@@ -1,17 +1,21 @@
 defmodule Schole.Search.Postgres do
   @moduledoc false
 
-  @behaviour Schole.Search
-
   import Ecto.Query
 
   alias Schole.Documents.Document
   alias Schole.Repo
 
-  def search(query) do
-    q = from d in Document,
-      where: ilike(d.content, ^"%#{query}%")
+  defmodule ILike do
+    @moduledoc false
 
-    Repo.all(q)
+    @behaviour Schole.Search
+
+    def search(query) do
+      q = from d in Document,
+        where: ilike(d.content, ^"%#{query}%")
+
+      Repo.all(q)
+    end
   end
 end

--- a/lib/schole/search/search.ex
+++ b/lib/schole/search/search.ex
@@ -1,10 +1,9 @@
 defmodule Schole.Search do
   @moduledoc false
 
-  @default_driver Schole.Search.Postgres
+  @default_driver Schole.Search.Postgres.ILike
 
   alias Schole.Documents.Document
-  alias Schole.Search.Postgres
 
   @type query :: String
   @type documents :: [Document]
@@ -13,7 +12,11 @@ defmodule Schole.Search do
 
   @spec search(query) :: documents
   def search(query) do
-    driver = Application.get_env(:schole, :search)[:driver] || @default_driver
+    driver = select_search_driver()
     driver.search(query)
+  end
+
+  defp select_search_driver() do
+    Application.get_env(:schole, :search)[:driver] || @default_driver
   end
 end

--- a/lib/schole/search/search.ex
+++ b/lib/schole/search/search.ex
@@ -1,0 +1,19 @@
+defmodule Schole.Search do
+  @moduledoc false
+
+  @default_driver Schole.Search.Postgres
+
+  alias Schole.Documents.Document
+  alias Schole.Search.Postgres
+
+  @type query :: String
+  @type documents :: [Document]
+
+  @callback search(query) :: documents
+
+  @spec search(query) :: documents
+  def search(query) do
+    driver = Application.get_env(:schole, :search)[:driver] || @default_driver
+    driver.search(query)
+  end
+end

--- a/lib/schole_web/schema/content_types.ex
+++ b/lib/schole_web/schema/content_types.ex
@@ -4,7 +4,6 @@ defmodule ScholeWeb.Schema.ContentTypes do
   use Absinthe.Schema.Notation
   import_types(ScholeWeb.Schema.JSONScalar)
   alias Schole.Repo
-  alias ScholeWeb.Resolvers.DocumentsResolver
 
   @desc "A Schole documentation project"
   object :project do


### PR DESCRIPTION
This updates the Schole configuration to allow for selecting the search implementation via `config.exs` (or the relevant env-specific config).

Fixes #9